### PR TITLE
Various adjustments and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 install:
-	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
-	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+        install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+        install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+        install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+	      install -Dm755 arch-luks-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
+	      install -Dm755 initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
+	      install -Dm644 systemd-suspend.service "$(DESTDIR)/etc/systemd/system/ykfde-suspend.service"
 reinstall:
-	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+        install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+        install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+        install -Dm755 arch-luks-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
+        install -Dm755 initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
+        install -Dm644 systemd-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 test:
 	./testrun.sh

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 install:
-        install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
-        install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-        install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
-	      install -Dm755 arch-luks-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
-	      install -Dm755 initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
-	      install -Dm644 systemd-suspend.service "$(DESTDIR)/etc/systemd/system/ykfde-suspend.service"
+	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks/ykfde"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install/ykfde"
+	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-suspend"
+	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
+	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 reinstall:
-        install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-        install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
-        install -Dm755 arch-luks-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
-        install -Dm755 initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
-        install -Dm644 systemd-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
+	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
+	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 test:
 	./testrun.sh

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install:
-	cp src/ykfde.conf /etc/ykfde.conf
-	cp src/hooks/ykfde /usr/lib/initcpio/hooks
-	cp src/install/ykfde /usr/lib/initcpio/install
+	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
 reinstall:
-	cp src/hooks/ykfde /usr/lib/initcpio/hooks
-	cp src/install/ykfde /usr/lib/initcpio/install
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
 test:
 	./testrun.sh

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
-	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open
+	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
 reinstall:
 	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
 	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
@@ -14,6 +14,6 @@ reinstall:
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
-	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open
+	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
 test:
 	./testrun.sh

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,15 @@ install:
 	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-suspend"
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
+	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
+	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open
 reinstall:
 	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
 	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
 	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
+	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
+	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open
 test:
 	./testrun.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,5 +17,5 @@ pkgver() {
 
 package() {
 	cd "${pkgname}"
-        make DESTDIR)=${pkgdir} install
+        make DESTDIR=${pkgdir} install
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,21 @@
+pkgname=yubikey-full-disk-encryption
+pkgver=r24.5099b2e
+pkgrel=1
+pkgdesc='Use YubiKey to unlock a LUKS partition'
+arch=('any')
+url='https://github.com/agherzan/yubikey-full-disk-encryption'
+license=('GPL')
+depends=('yubikey-personalization' 'cryptsetup')
+backup=('etc/ykfde.conf')
+source=('git+https://github.com/agherzan/yubikey-full-disk-encryption.git')
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${pkgname}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+	cd "${pkgname}"
+        make DESTDIR)=${pkgdir} install
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Reboot and test you configuration.
 
 ## Enable ykfde-suspend module
 
-You can enable ykfde-suspend module which allows for automatically locking encrypted LUKS containers and wiping keys from memory on suspend and unlocking them on resume by using luksSuspend, luksResume commands.)
+You can enable ykfde-suspend module which allows for automatically locking encrypted LUKS containers and wiping keys from memory on suspend and unlocking them on resume by using luksSuspend, luksResume commands. Based on https://github.com/vianney/arch-luks-suspend
+
+1. Edit /etc/mkinitcpio.conf and make sure the following hooks are enabled:udev, shutdown, suspend.
+2. Enable related systemd service:
 
 ```
 systemctl enable ykfde-suspend.service

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Use the response as a new key for your LUKS partition:
 cryptsetup luksAddKey /dev/<device>
 ```
 
+You can also use existing ykfde-enroll script, see ykfde-enroll -h for help.
+```
+sudo ykfde-enroll -d /dev/<device> -s <keyslot_number>
+```
+For unlocking existing device on running system you can use ykfde-open script, see ykfde-open -h for help
+```
+sudo ykfde-open -d /dev/<device> -n <container_name>
+```
+
 ## Initramfs hooks instalation and configuration
 
 Install all the needed scripts by issuing:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Reboot and test you configuration.
 
 You can enable ykfde-suspend module which allows for automatically locking encrypted LUKS containers and wiping keys from memory on suspend and unlocking them on resume by using luksSuspend, luksResume commands. Based on https://github.com/vianney/arch-luks-suspend
 
-1. Edit /etc/mkinitcpio.conf and make sure the following hooks are enabled:udev, shutdown, suspend.
+1. Edit /etc/mkinitcpio.conf and make sure the following hooks are enabled: udev, ykfde, shutdown.
 2. Enable related systemd service:
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ sudo mkinitcpio -p linux
 
 Reboot and test you configuration.
 
+## Enable ykfde-suspend module
+
+You can enable ykfde-suspend module which allows for automatically locking encrypted LUKS containers and wiping keys from memory on suspend and unlocking them on resume by using luksSuspend, luksResume commands.)
+
+```
+systemctl enable ykfde-suspend.service
+```
+
 ## Improvements
 
 * Added DBG mode (turned on via etc/ykfde.conf if things don't work like they should and you would like to *exactly* understand what is going on ;))
@@ -77,6 +85,11 @@ Reboot and test you configuration.
 * Made the hook/ykfde script overall more robust against typos, less error prone
 * Added YubiKey detection (to complete the wait for yubiKey functionality of hook/ykfde script)
 * Added a testrun.sh Test script to test the hook not first during boot-up ;)
+* Added ykfde-suspend module
+* Fixes most issues detected by shellcheck static analysis tool
+* Adds makepkg integration and PKGBUILD
+* Hash password with sha256.
+* Adds ykfde-open and ykfde-enroll scripts
 
 ## Security
 

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -34,6 +34,7 @@ ykfde_challenge_response() {
       echo " > Please provide password which will be used as challenge."
       while [ -z "$_pw" ]; do
       printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+      _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
       done
       [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
       YKFDE_CHALLENGE="$_pw"

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -64,7 +64,7 @@ ykfde_challenge_response() {
     [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
     if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-      _passphrase="$_passphrase$_pw"
+      _passphrase="$_pw$_passphrase"
     fi
 }
 

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -21,28 +21,28 @@ ykfde_challenge_response() {
     local _tmp="";
     local _rc="";
 
-    [ $YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT -gt 0 ] && _yubikey_timeout_str="$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT seconds"
+    [ "$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT" -gt 0 ] && _yubikey_timeout_str="$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT seconds"
 
     # Challenge is provided so let's try yubikey
     _starttime=$(date +%s)
     echo " > Waiting $_yubikey_timeout_str for YubiKey..."
 
     while [ -z "$_yubikey_detected" ]; do
-      _endtime=$(date +%s); _usedtime=$(( $_endtime - $_starttime ));
+      _endtime=$(date +%s); _usedtime=$(( _endtime - _starttime ));
     if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
       local _pw="";
       echo " > Please provide password which will be used as challenge."
       while [ -z "$_pw" ]; do
-      printf "   Enter password: "; if [ $DBG ]; then read _pw; else read -s _pw; fi
+      printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
       done
-      [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
+      [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
       YKFDE_CHALLENGE="$_pw"
     fi
-      [ $DBG ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
-      _tmp="$(ykinfo -$YKFDE_CHALLENGE_SLOT 2>&1)"; _rc=$?;
-      [ $DBG ] && echo "[$_rc] '$_tmp'"
+      [ "$DBG" ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+      _tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)"; _rc=$?;
+      [ "$DBG" ] && echo "[$_rc] '$_tmp'"
       [ $_rc -eq 0 ] && _yubikey_detected=1;
-      if [ $_yubikey_timeout -eq -1 -o $_usedtime -le $_yubikey_timeout ]; then
+      if [ "$_yubikey_timeout" -eq -1 ] || [ $_usedtime -le "$_yubikey_timeout" ]; then
           sleep 0.5
       else
           echo "    TIMEOUT - Giving up with Challenge-Response!"
@@ -50,19 +50,19 @@ ykfde_challenge_response() {
       fi
     done
     echo "   YubiKey detected! - Don't forget to press its button if necessary..."
-    [ $DBG ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
-    _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+    [ "$DBG" ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+    _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     if [ -z "$_passphrase" ]; then
       printf "\n   NO response from YubiKey!? - We try again! (so press the button now?!)...\n"
-      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+      _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     fi
     if [ -z "$_passphrase" ]; then
       printf "\n   NO response from YubiKey!? - Last trial of ykchalresp...\n"
-      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+      _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     fi
-    [ $DBG ] && printf "\n   Got as response: '$_passphrase'\n"
+    [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
-    if [ -n "$_passphrase" -a "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
       _passphrase="$_passphrase$_pw"
     fi
 }
@@ -80,28 +80,28 @@ ykfde_do_it() {
     if [ -z "$_passphrase" ]; then
         if [ -n "$YKFDE_CHALLENGE" ]; then
           printf " > Failed to do challenge-response.\n   Falling back to manual passphrase entering to unlock the disk.\n"
-          [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ] && echo "   Just press ENTER to skip and to try Challenge-Response again."
+          [ "$trial_nr" -le "$YKFDE_CRYPTSETUP_TRIALS" ] && echo "   Just press ENTER to skip and to try Challenge-Response again."
         else
           echo " > We need the passphrase to unlock the disk."
         fi
 
-        printf "   Enter passphrase: "; if [ $DBG ]; then read _passphrase; else read -s _passphrase; fi
-        [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
+        printf "   Enter passphrase: "; if [ "$DBG" ]; then read -r _passphrase; else read -r -s _passphrase; fi
+        [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
     fi
 
     [ -e "$YKFDE_LUKS_DEV" ] || { ykfde_err 003 "ykfde can't find LUKS device '$YKFDE_LUKS_DEV'.\nPlease check YKFDE_DISK_UUID ($YKFDE_DISK_UUID) and/or YKFDE_LUKS_DEV variable(s) in '$YKFDE_CONFIG_FILE'."; return 1; }
 
-    [ $DBG ] && echo " > Using '$_passphrase' with cryptsetup!"
-    [ $DBG ] && echo " > Decrypting (cryptsetup luksOpen "$YKFDE_LUKS_DEV" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
+    [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
+    [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
 
-    _tmp="$(printf "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
+    _tmp="$(printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
     _rc=$?;
 
     if [ $_rc -eq 0 ]; then
         echo "   SUCCESS :)";
-        if [ -n "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP -gt 0 ]; then
-          [ $DBG ] && echo " > Sleeping $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP bevore moving on..."
-          sleep $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP
+        if [ -n "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" -gt 0 ]; then
+          [ "$DBG" ] && echo " > Sleeping $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP bevore moving on..."
+          sleep "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP"
         fi;
     else
         echo "   FAILED! [$_rc] $_tmp";
@@ -114,12 +114,12 @@ ykfde_do_it() {
 run_hook() {
     local _tmp=""
 
-    [ $DBG ] && echo "$0:"
+    [ "$DBG" ] && echo "$0:"
 
-    [ $DBG ] && echo " > Reading YKFDE_CONFIG_FILE..."
+    [ "$DBG" ] && echo " > Reading YKFDE_CONFIG_FILE..."
     . "$YKFDE_CONFIG_FILE" || { ykfde_err 001 "Failed reading YKFDE_CONFIG_FILE '$YKFDE_CONFIG_FILE'"; return 1; }
 
-    [ -z "$YKFDE_DISK_UUID" -o -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
+    [ -z "$YKFDE_DISK_UUID" ] || [ -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
 
     # set default values:
     [ -z "$YKFDE_LUKS_DEV" ] && YKFDE_LUKS_DEV="/dev/disk/by-uuid/$YKFDE_DISK_UUID"
@@ -129,10 +129,10 @@ run_hook() {
     # sanity checks:
     [ $YKFDE_CRYPTSETUP_TRIALS -gt 0 ] || { ykfde_err 006 "YKFDE_CRYPTSETUP_TRIALS needs to be a number > 0."; return 1; }
 
-    [ $DBG ] && echo " > udevadm settle..."
+    [ "$DBG" ] && echo " > udevadm settle..."
     udevadm settle || { ykfde_err 004 "Failed to 'udevadm settle'"; return 1; }
 
-    [ $DBG ] && echo " > modprobe -a -q dm-crypt..."
+    [ "$DBG" ] && echo " > modprobe -a -q dm-crypt..."
     tmp="$(modprobe -a dm-crypt 2>&1)" || { ykfde_err 005 "FAILED to 'modprobe -a -q dm-crypt':\n$tmp"; return 1; }
 
     local trial_nr=1;
@@ -140,7 +140,7 @@ run_hook() {
     while [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ]; do
       printf "\nTRIAL #$trial_nr/$YKFDE_CRYPTSETUP_TRIALS: cryptsetup of $what\n"
       ykfde_do_it && return 0;
-      trial_nr=$(( $trial_nr + 1 ));
+      trial_nr=$(( trial_nr + 1 ));
     done
 
     # if we get here, we did NOT succeed:

--- a/src/initramfs-suspend
+++ b/src/initramfs-suspend
@@ -1,0 +1,59 @@
+#!/usr/bin/ash
+
+cryptname="${1}"
+
+# Start udev from initramfs
+/usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
+
+# Synchronize filesystems before luksSuspend
+sync
+
+# Suspend root device
+[ -z "${cryptname}" ] || cryptsetup luksSuspend "${cryptname}"
+
+# Suspend the system
+echo mem > /sys/power/state
+
+# Resume root device
+. /etc/ykfde.conf
+
+
+[ -z "${cryptname}" ] ||
+    while true; do
+        if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+            echo " > Please provide password which will be used as challenge."
+            while [ -z "$_pw" ]; do
+            printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+            done
+            [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
+            YKFDE_CHALLENGE="$_pw"
+        fi
+
+        [ "$DBG" ] && printf "   ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+        _tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)";
+        [ "$DBG" ] && echo "$_tmp"
+        [ "$DBG" ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+        _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+        if [ -z "$_passphrase" ]; then
+            printf "\n   NO response from YubiKey!? - We try again! (so press the button now?!)...\n"
+            _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+        fi
+
+        if [ -z "$_passphrase" ]; then
+            printf "\n   NO response from YubiKey!? - Last trial of ykchalresp...\n"
+            _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+        fi
+        [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
+
+        if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+            _passphrase="$_passphrase$_pw"
+        fi
+        [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
+        [ "$DBG" ] && echo " > Decrypting (cryptsetup luksResume \"${cryptname}\")..." || echo " > Decrypting (cryptsetup luksResume)..."
+        printf %s "$_passphrase"| cryptsetup luksResume "${cryptname}" 2>&1;
+        [ $? -le 1 ] && break
+        sleep 2
+    done
+
+# Stop udev from initramfs, as the real daemon from rootfs will be restarted
+udevadm control --exit

--- a/src/initramfs-suspend
+++ b/src/initramfs-suspend
@@ -47,7 +47,7 @@ echo mem > /sys/power/state
         [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
         if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-            _passphrase="$_passphrase$_pw"
+            _passphrase="$_pw$_passphrase"
         fi
         [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
         [ "$DBG" ] && echo " > Decrypting (cryptsetup luksResume \"${cryptname}\")..." || echo " > Decrypting (cryptsetup luksResume)..."

--- a/src/initramfs-suspend
+++ b/src/initramfs-suspend
@@ -24,6 +24,7 @@ echo mem > /sys/power/state
             echo " > Please provide password which will be used as challenge."
             while [ -z "$_pw" ]; do
             printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+            _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
             done
             [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
             YKFDE_CHALLENGE="$_pw"

--- a/src/install/ykfde
+++ b/src/install/ykfde
@@ -26,6 +26,7 @@ build() {
     add_binary "sleep"
     add_binary "printf"
     add_file "/etc/ykfde.conf" "/etc/ykfde.conf"
+    add_file "/usr/lib/ykfde-suspend/initramfs-suspend" "/suspend" 755
 
     add_runscript
 }

--- a/src/install/ykfde
+++ b/src/install/ykfde
@@ -26,7 +26,7 @@ build() {
     add_binary "sleep"
     add_binary "printf"
     add_file "/etc/ykfde.conf" "/etc/ykfde.conf"
-    add_file "/usr/lib/ykfde-suspend/initramfs-suspend" "/suspend" 755
+    add_file "/usr/lib/ykfde-suspend/initramfs-suspend" "/bin/suspend" 755
 
     add_runscript
 }

--- a/src/ykfde-enroll
+++ b/src/ykfde-enroll
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+CLEAR_KEY_SLOT=0
+
+set -e
+. /etc/ykfde.conf
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "You must be root." 1>&2
+  exit 1
+fi
+
+while getopts ":s:d:hcv" opt; do
+  case $opt in
+	s)
+		KEY_SLOT=$OPTARG
+		echo "setting LUKS key slot to $OPTARG."
+		;;
+	d)
+		YKFDE_LUKS_DEV=$OPTARG
+		echo "setting disk to $OPTARG."
+		;;
+	c)      CLEAR_KEY_SLOT=1
+		echo "clearing LUKS key slot"
+		;;
+	v)      DBG=1
+		echo "debugging enabled"
+		;;
+	h)
+		echo 
+		echo " -d <partition>: set the partition"
+		echo " -s <slot>     : set the slot"
+		echo " -c            : clear the slot prior to writing"
+		echo " -v            : show input/output in cleartext"
+		echo
+		exit 1
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		;;
+  esac
+done
+
+if [ -z "$YKFDE_LUKS_DEV" ]; then
+    echo "Please select existing partition using -d option, see ykfde-enroll -h for help."
+    exit 1
+fi
+
+if [ -z "$KEY_SLOT" ]; then
+    echo "Please select LUKS key slot using -s option, see ykfde-enroll -h for help."
+    exit 1
+fi
+
+if [ $CLEAR_KEY_SLOT -eq 1 ]; then
+	echo "Killing LUKS slot $KEY_SLOT"
+	cryptsetup luksKillSlot "$YKFDE_LUKS_DEV" "$KEY_SLOT"
+fi
+
+echo "This script will utilize slot $KEY_SLOT on drive $YKFDE_LUKS_DEV.  If this is not what you intended, exit now!"
+
+if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    echo " > Please provide password which will be used as challenge."
+    while [ -z "$_pw" ]; do
+    printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+    echo " > Please provide the same password again."
+    printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw2; else read -r -s _pw2; fi
+    if [ "$_pw" != "$_pw2" ]; then
+	echo "Passwords do not match"
+	exit 1
+    fi
+    _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+    done
+    [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
+    YKFDE_CHALLENGE="$_pw"
+fi
+
+[ "$DBG" ] && printf "   ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+_tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)";
+[ "$DBG" ] && echo "$_tmp"
+
+echo "   Don't forget to press its button if necessary..."
+[ "$DBG" ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+_passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+
+if [ -z "$_passphrase" ]; then
+    printf "\n   NO response from YubiKey!? - We try again! (so press the button now?!)...\n"
+    _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+fi
+
+[ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
+
+if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    _passphrase="$_passphrase$_pw"
+fi
+
+[ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
+echo "You may now be prompted for an existing passphrase. This is NOT the passphrase you just entered, this is the passphrase that you currently use to unlock your LUKS encrypted drive."
+printf "   Enter password: "; if [ "$DBG" ]; then read -r OLD; else read -r -s OLD; fi
+[ "$DBG" ] && echo " > Adding new LUKS key (cryptsetup --key-slot=\"$KEY_SLOT\" luksAddKey \"$YKFDE_LUKS_DEV\")..." || echo " > Decrypting (cryptsetup luksAddKey)..."
+printf '%s\n' "$OLD" "$_passphrase" "$_passphrase" | cryptsetup --key-slot="$KEY_SLOT" luksAddKey "$YKFDE_LUKS_DEV" 2>&1;
+
+exit 0

--- a/src/ykfde-enroll
+++ b/src/ykfde-enroll
@@ -19,10 +19,10 @@ while getopts ":s:d:hcv" opt; do
 		YKFDE_LUKS_DEV=$OPTARG
 		echo "setting disk to $OPTARG."
 		;;
-	c)      CLEAR_KEY_SLOT=1
+	c)	CLEAR_KEY_SLOT=1
 		echo "clearing LUKS key slot"
 		;;
-	v)      DBG=1
+	v)	DBG=1
 		echo "debugging enabled"
 		;;
 	h)

--- a/src/ykfde-enroll
+++ b/src/ykfde-enroll
@@ -89,7 +89,7 @@ fi
 [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
 if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-    _passphrase="$_passphrase$_pw"
+    _passphrase="$_pw$_passphrase"
 fi
 
 [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -18,7 +18,7 @@ while getopts ":d:n:hv" opt; do
 		YKFDE_LUKS_NAME=$OPTARG
 		echo "setting name to $OPTARG."
 		;;
-	v)      DBG=1
+	v)	DBG=1
 		echo "debugging enabled"
 		;;
 	h)

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+. /etc/ykfde.conf
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "You must be root." 1>&2
+  exit 1
+fi
+
+while getopts ":d:n:hv" opt; do
+  case $opt in
+	d)
+		YKFDE_LUKS_DEV=$OPTARG
+		echo "setting disk to $OPTARG."
+		;;
+	n)
+		YKFDE_LUKS_NAME=$OPTARG
+		echo "setting name to $OPTARG."
+		;;
+	v)      DBG=1
+		echo "debugging enabled"
+		;;
+	h)
+		echo 
+		echo " -d <partition>: select existing partition"
+		echo " -n <name>     : set the new container name"
+		echo " -v            : show input/output in cleartext"
+		echo
+		exit 1
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		;;
+  esac
+done
+
+if [ -z "$YKFDE_LUKS_DEV" ]; then
+    echo "Please select existing partition using -d option, see ykfde-open -h for help."
+    exit 1
+fi
+
+echo "This script will try opening $YKFDE_LUKS_NAME LUKS container on drive $YKFDE_LUKS_DEV . If this is not what you intended, exit now!"
+
+
+if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    echo " > Please provide password which will be used as challenge."
+    while [ -z "$_pw" ]; do
+    printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+    _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+    done
+    [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
+    YKFDE_CHALLENGE="$_pw"
+fi
+
+[ "$DBG" ] && printf "   ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+_tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)";
+[ "$DBG" ] && echo "$_tmp"
+
+echo "   Don't forget to press its button if necessary..."
+[ "$DBG" ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+_passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+
+if [ -z "$_passphrase" ]; then
+    printf "\n   NO response from YubiKey!? - We try again! (so press the button now?!)...\n"
+    _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+fi
+
+[ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
+
+if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    _passphrase="$_passphrase$_pw"
+fi
+
+[ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
+[ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
+printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1;
+
+exit 0

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -69,7 +69,7 @@ fi
 [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
 if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-    _passphrase="$_passphrase$_pw"
+    _passphrase="$_pw$_passphrase"
 fi
 
 [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -e -u
+trap 'echo "Press ENTER to continue."; read dummy' ERR
+
+################################################################################
+## Parameters and helper functions
+
+INITRAMFS_DIR=/run/initramfs
+SYSTEM_SLEEP_PATH=/usr/lib/systemd/system-sleep
+BIND_PATHS="/sys /proc /dev /run"
+REMOUNT=0
+# Retrieve cryptdevice name from boot cmdline
+CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
+
+# run_dir DIR ARGS...
+# Run all executable scripts in directory DIR with arguments ARGS
+run_dir() {
+    local dir=$1
+    shift
+    find "${dir}" -type f -executable -exec "{}" "$@" ";"
+}
+
+# Restore chroot
+umount_initramfs() {
+    local p
+    for p in ${BIND_PATHS}; do
+        ! mountpoint -q "${INITRAMFS_DIR}${p}" || umount "${INITRAMFS_DIR}${p}"
+    done
+}
+
+cryptdevice_mount_options() {
+    local mt
+    mt="$(grep "^/dev/mapper/${1} " /proc/mounts | cut -d ' ' -f 3,4 | head -n 1)"
+    local fs
+    fs="$(cut -d ' ' -f 1 <<< "${mt}")"
+    local opt
+    opt="$(cut -d ' ' -f 2 <<< "${mt}")"
+    if [[ "${fs}" == "ext4" || "${fs}" == "btrfs" ]]; then
+        echo "${opt}"
+    fi
+}
+
+################################################################################
+## Main script
+
+[ -e "${INITRAMFS_DIR}/suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
+
+# Prepare chroot
+trap umount_initramfs EXIT
+for p in ${BIND_PATHS}; do
+    mount -o bind "${p}" "${INITRAMFS_DIR}${p}"
+done
+
+# Run pre-suspend scripts
+run_dir "${SYSTEM_SLEEP_PATH}" pre suspend
+
+# Stop udev service and prevent it to be autostarted.
+# Otherwise, luksResume will hang waiting for udev, which is itself waiting
+# for I/O on the root device.
+systemctl stop systemd-udevd-control.socket
+systemctl stop systemd-udevd-kernel.socket
+systemctl stop systemd-udevd.service
+
+systemctl stop systemd-journald.socket
+systemctl stop systemd-journald-dev-log.socket
+systemctl stop systemd-journald.service
+
+# Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
+# if mounted with `barrier=1`, which is the default. Temporarily remount with
+# `barrier=0` if this is true of the crypt fs.
+MOUNT_OPTS="$(cryptdevice_mount_options "$CRYPTNAME")"
+if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == *barrier=0* ]]; then
+    REMOUNT=1
+    mount -o remount,"$MOUNT_OPTS",barrier=0 /
+fi
+
+# Hand over execution to script inside initramfs
+cd "${INITRAMFS_DIR}"
+chroot . /suspend "$CRYPTNAME"
+
+# Restore original mount options if necessary
+if ((REMOUNT)); then
+    mount -o remount,"$MOUNT_OPTS",barrier=1 /
+fi
+
+systemctl start systemd-journald.service
+systemctl start systemd-journald-dev-log.socket
+systemctl start systemd-journald.socket
+
+# Restart udev
+systemctl start systemd-udevd-control.socket
+systemctl start systemd-udevd-kernel.socket
+systemctl start systemd-udevd.service
+
+# Run post-suspend scripts
+run_dir "${SYSTEM_SLEEP_PATH}" post suspend
+
+# Unlock user sessions
+loginctl unlock-sessions

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -75,6 +75,9 @@ if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == 
     mount -o remount,"$MOUNT_OPTS",barrier=0 /
 fi
 
+# Synchronize filesystems before luksSuspend   
+sync
+
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
 chroot . /bin/suspend "$CRYPTNAME"

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -44,7 +44,7 @@ cryptdevice_mount_options() {
 ################################################################################
 ## Main script
 
-[ -e "${INITRAMFS_DIR}/suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
+[ -e "${INITRAMFS_DIR}/bin/suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
 
 # Prepare chroot
 trap umount_initramfs EXIT
@@ -77,7 +77,7 @@ fi
 
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
-chroot . /suspend "$CRYPTNAME"
+chroot . /bin/suspend "$CRYPTNAME"
 
 # Restore original mount options if necessary
 if ((REMOUNT)); then

--- a/src/ykfde-suspend.service
+++ b/src/ykfde-suspend.service
@@ -1,0 +1,20 @@
+#  This file has been adapted from systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Suspend
+Documentation=man:systemd-suspend.service(8)
+DefaultDependencies=no
+Requires=sleep.target
+After=sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/openvt -ws /usr/lib/ykfde-suspend/ykfde-suspend
+
+[Install]
+Alias=systemd-suspend.service


### PR DESCRIPTION
- Adds suspend module and resolves https://github.com/agherzan/yubikey-full-disk-encryption/issues/8
- Fixes most issues detected by shellcheck static analysis tool https://github.com/agherzan/yubikey-full-disk-encryption/pull/12#issue-276676321
- It allows for `make DESTDIR=${pkgdir} install` in pacman or any other package manager. Invoking `make install` has the same behavior as before. Also it adds PKGBUILD so everyone can easy create package and install it through pacman. It can be uploaded to AUR for better project discovery.
- Hash password with sha256. Using password as challenge can have some drawbacks. Password can be very weak like "aaa". Password can be longer than 64 characters which is max for yubikey challenge which result in breakage. As solution we can hash the password with sha256 which give us 64 characters (maximum) length challenge for any user provided password. In result we have 104 (64+40) characters long LUKS passphrase. This change means all users have to recreate their LUKS keys if password was used.
- Adds ykfde-open and ykfde-enroll scripts for easy adding new keys and opening containers outside initramfs. Resolves https://github.com/agherzan/yubikey-full-disk-encryption/issues/9
- Adds info to readme about LUKS passphrase creation scheme