### PR TITLE
Fix issues detected by shellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 install:
 	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
-	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks/ykfde"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install/ykfde"
+	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-suspend"
+	install -Dm755 src/encrypt-on-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/encrypt-on-suspend"
+	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
+
 reinstall:
 	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
 	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
+	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-suspend"
+	install -Dm755 src/encrypt-on-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/encrypt-on-suspend"
+	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
+  
 test:
 	./testrun.sh

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install:
-	cp src/ykfde.conf /etc/ykfde.conf
-	cp src/hooks/ykfde /usr/lib/initcpio/hooks
-	cp src/install/ykfde /usr/lib/initcpio/install
+	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
 reinstall:
-	cp src/hooks/ykfde /usr/lib/initcpio/hooks
-	cp src/install/ykfde /usr/lib/initcpio/install
+	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
+	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
 test:
 	./testrun.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,21 @@
+pkgname=yubikey-full-disk-encryption
+pkgver=r24.5099b2e
+pkgrel=1
+pkgdesc='Use YubiKey to unlock a LUKS partition'
+arch=('any')
+url='https://github.com/agherzan/yubikey-full-disk-encryption'
+license=('GPL')
+depends=('yubikey-personalization' 'cryptsetup')
+backup=('etc/ykfde.conf')
+source=('git+https://github.com/agherzan/yubikey-full-disk-encryption.git')
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${pkgname}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+	cd "${pkgname}"
+        make DESTDIR=${pkgdir} install
+}

--- a/src/encrypt-on-suspend
+++ b/src/encrypt-on-suspend
@@ -1,8 +1,42 @@
 #!/usr/bin/env bash
+# Copyright 2013 Vianney le Clément de Saint-Marcq <vleclement@gmail.com>  
+# Copyright 2017 Zhongfu Li <me@zhongfu.li>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with This program.  If not, see http://www.gnu.org/licenses/.
+
+cryptname="${1}"
+trap stop_udev EXIT
+
+stop_udev() {
+  # Stop udev from initramfs, as the real daemon from rootfs will be restarted
+  udevadm control --exit
+}
+
+# Start udev from initramfs
+/usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
+
+# Synchronize filesystems before luksSuspend 
+sync
+
+# Suspend root device
+[ -z "${cryptname}" ] || cryptsetup luksSuspend "${cryptname}"
+
+# Suspend the system
+echo mem > /sys/power/state
 
 YKFDE_CONFIG_FILE="/etc/ykfde.conf"
 
-DEFAULT_CRYPTSETUP_TRIALS=5;                   # defaults number of times to try 'do_it()' -- so: assemble passphrase and run 'cryptsetup luksOpen'
+DEFAULT_CRYPTSETUP_TRIALS=5;                   # defaults number of times to try 'do_it()' -- so: assemble passphrase and run 'cryptsetup luksResume'
 DEFAULT_CHALLENGE_YUBIKEY_INSERT_TIMEOUT=30;   # default value for YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT. -1 = unlimited
 
 
@@ -36,11 +70,13 @@ ykfde_challenge_response() {
       printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
       done
       [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
-      
+
       # Hash provided password with sha256
-      _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+      #while [ -n "$_pw" ]; do
+      #_pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+      #done
+
       YKFDE_CHALLENGE="$_pw"
-      [ $DBG ] && echo "     Yubikey challenge: \"$YKFDE_CHALLENGE\""
     fi
       [ "$DBG" ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
       _tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)"; _rc=$?;
@@ -72,9 +108,9 @@ ykfde_challenge_response() {
 }
 
 
-# assemble passphrase and run 'cryptsetup luksOpen'
+# assemble passphrase and run 'cryptsetup luksResume'
 ykfde_do_it() {
-    local _passphrase=""                     # key used to 'cryptsetup luksOpen'
+    local _passphrase=""                     # key used to 'cryptsetup luksResume'
     local _tmp="";
     local _rc="";
 
@@ -93,12 +129,10 @@ ykfde_do_it() {
         [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
     fi
 
-    [ -e "$YKFDE_LUKS_DEV" ] || { ykfde_err 003 "ykfde can't find LUKS device '$YKFDE_LUKS_DEV'.\nPlease check YKFDE_DISK_UUID ($YKFDE_DISK_UUID) and/or YKFDE_LUKS_DEV variable(s) in '$YKFDE_CONFIG_FILE'."; return 1; }
-
     [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
-    [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
+    [ "$DBG" ] && echo " > Decrypting (cryptsetup luksResume \"${cryptname}\")..." || echo " > Decrypting (cryptsetup luksResume)..."
 
-    _tmp="$(printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
+    _tmp="$(printf %s "$_passphrase"| cryptsetup luksResume "${cryptname}" 2>&1)";
     _rc=$?;
 
     if [ $_rc -eq 0 ]; then
@@ -123,10 +157,7 @@ run_hook() {
     [ "$DBG" ] && echo " > Reading YKFDE_CONFIG_FILE..."
     . "$YKFDE_CONFIG_FILE" || { ykfde_err 001 "Failed reading YKFDE_CONFIG_FILE '$YKFDE_CONFIG_FILE'"; return 1; }
 
-    [ -z "$YKFDE_DISK_UUID" ] || [ -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
-
     # set default values:
-    [ -z "$YKFDE_LUKS_DEV" ] && YKFDE_LUKS_DEV="/dev/disk/by-uuid/$YKFDE_DISK_UUID"
     [ -z "$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT" ] && YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT="$DEFAULT_CHALLENGE_YUBIKEY_INSERT_TIMEOUT"
     [ -z "$YKFDE_CRYPTSETUP_TRIALS" ] && YKFDE_CRYPTSETUP_TRIALS="$DEFAULT_CRYPTSETUP_TRIALS"
 
@@ -140,7 +171,7 @@ run_hook() {
     tmp="$(modprobe -a dm-crypt 2>&1)" || { ykfde_err 005 "FAILED to 'modprobe -a -q dm-crypt':\n$tmp"; return 1; }
 
     local trial_nr=1;
-    local what="$YKFDE_DISK_UUID"; [ -n "$YKFDE_LUKS_NAME" ] && s=" $YKFDE_LUKS_NAME";
+    local what="${cryptname}";
     while [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ]; do
       printf "\nTRIAL #$trial_nr/$YKFDE_CRYPTSETUP_TRIALS: cryptsetup of $what\n"
       ykfde_do_it && return 0;
@@ -151,4 +182,3 @@ run_hook() {
     ykfde_err 000 "$0 FAILED !"
     return 1;
 }
-

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -36,6 +36,12 @@ ykfde_challenge_response() {
       printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
       done
       [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
+      
+      # Hash provided password with sha256
+      while [ -n "$_pw" ]; do
+      _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+      done
+      
       YKFDE_CHALLENGE="$_pw"
     fi
       [ "$DBG" ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -100,7 +100,7 @@ ykfde_do_it() {
     [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
     [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
 
-    _tmp="$(printf "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
+    _tmp="$(printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
     _rc=$?;
 
     if [ $_rc -eq 0 ]; then

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -21,28 +21,28 @@ ykfde_challenge_response() {
     local _tmp="";
     local _rc="";
 
-    [ $YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT -gt 0 ] && _yubikey_timeout_str="$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT seconds"
+    [ "$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT" -gt 0 ] && _yubikey_timeout_str="$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT seconds"
 
     # Challenge is provided so let's try yubikey
     _starttime=$(date +%s)
     echo " > Waiting $_yubikey_timeout_str for YubiKey..."
 
     while [ -z "$_yubikey_detected" ]; do
-      _endtime=$(date +%s); _usedtime=$(( $_endtime - $_starttime ));
+      _endtime=$(date +%s); _usedtime=$(( _endtime - _starttime ));
     if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
       local _pw="";
       echo " > Please provide password which will be used as challenge."
       while [ -z "$_pw" ]; do
-      printf "   Enter password: "; if [ $DBG ]; then read _pw; else read -s _pw; fi
+      printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
       done
-      [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
+      [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
       YKFDE_CHALLENGE="$_pw"
     fi
-      [ $DBG ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
-      _tmp="$(ykinfo -$YKFDE_CHALLENGE_SLOT 2>&1)"; _rc=$?;
-      [ $DBG ] && echo "[$_rc] '$_tmp'"
+      [ "$DBG" ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+      _tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)"; _rc=$?;
+      [ "$DBG" ] && echo "[$_rc] '$_tmp'"
       [ $_rc -eq 0 ] && _yubikey_detected=1;
-      if [ $_yubikey_timeout -eq -1 -o $_usedtime -le $_yubikey_timeout ]; then
+      if [ "$_yubikey_timeout" -eq -1 ] || [ $_usedtime -le "$_yubikey_timeout" ]; then
           sleep 0.5
       else
           echo "    TIMEOUT - Giving up with Challenge-Response!"
@@ -50,19 +50,19 @@ ykfde_challenge_response() {
       fi
     done
     echo "   YubiKey detected! - Don't forget to press its button if necessary..."
-    [ $DBG ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
-    _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+    [ "$DBG" ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+    _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     if [ -z "$_passphrase" ]; then
       printf "\n   NO response from YubiKey!? - We try again! (so press the button now?!)...\n"
-      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+      _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     fi
     if [ -z "$_passphrase" ]; then
       printf "\n   NO response from YubiKey!? - Last trial of ykchalresp...\n"
-      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+      _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
     fi
-    [ $DBG ] && printf "\n   Got as response: '$_passphrase'\n"
+    [ "$DBG" ] && printf "\n   Got as response: '$_passphrase'\n"
 
-    if [ -n "$_passphrase" -a "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
+    if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
       _passphrase="$_passphrase$_pw"
     fi
 }
@@ -80,28 +80,28 @@ ykfde_do_it() {
     if [ -z "$_passphrase" ]; then
         if [ -n "$YKFDE_CHALLENGE" ]; then
           printf " > Failed to do challenge-response.\n   Falling back to manual passphrase entering to unlock the disk.\n"
-          [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ] && echo "   Just press ENTER to skip and to try Challenge-Response again."
+          [ "$trial_nr" -le "$YKFDE_CRYPTSETUP_TRIALS" ] && echo "   Just press ENTER to skip and to try Challenge-Response again."
         else
           echo " > We need the passphrase to unlock the disk."
         fi
 
-        printf "   Enter passphrase: "; if [ $DBG ]; then read _passphrase; else read -s _passphrase; fi
-        [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
+        printf "   Enter passphrase: "; if [ "$DBG" ]; then read -r _passphrase; else read -r -s _passphrase; fi
+        [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
     fi
 
     [ -e "$YKFDE_LUKS_DEV" ] || { ykfde_err 003 "ykfde can't find LUKS device '$YKFDE_LUKS_DEV'.\nPlease check YKFDE_DISK_UUID ($YKFDE_DISK_UUID) and/or YKFDE_LUKS_DEV variable(s) in '$YKFDE_CONFIG_FILE'."; return 1; }
 
-    [ $DBG ] && echo " > Using '$_passphrase' with cryptsetup!"
-    [ $DBG ] && echo " > Decrypting (cryptsetup luksOpen "$YKFDE_LUKS_DEV" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
+    [ "$DBG" ] && echo " > Using '$_passphrase' with cryptsetup!"
+    [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
 
     _tmp="$(printf "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
     _rc=$?;
 
     if [ $_rc -eq 0 ]; then
         echo "   SUCCESS :)";
-        if [ -n "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP -gt 0 ]; then
-          [ $DBG ] && echo " > Sleeping $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP bevore moving on..."
-          sleep $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP
+        if [ -n "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" -gt 0 ]; then
+          [ "$DBG" ] && echo " > Sleeping $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP bevore moving on..."
+          sleep "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP"
         fi;
     else
         echo "   FAILED! [$_rc] $_tmp";
@@ -114,12 +114,12 @@ ykfde_do_it() {
 run_hook() {
     local _tmp=""
 
-    [ $DBG ] && echo "$0:"
+    [ "$DBG" ] && echo "$0:"
 
-    [ $DBG ] && echo " > Reading YKFDE_CONFIG_FILE..."
+    [ "$DBG" ] && echo " > Reading YKFDE_CONFIG_FILE..."
     . "$YKFDE_CONFIG_FILE" || { ykfde_err 001 "Failed reading YKFDE_CONFIG_FILE '$YKFDE_CONFIG_FILE'"; return 1; }
 
-    [ -z "$YKFDE_DISK_UUID" -o -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
+    [ -z "$YKFDE_DISK_UUID" ] || [ -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
 
     # set default values:
     [ -z "$YKFDE_LUKS_DEV" ] && YKFDE_LUKS_DEV="/dev/disk/by-uuid/$YKFDE_DISK_UUID"
@@ -129,10 +129,10 @@ run_hook() {
     # sanity checks:
     [ $YKFDE_CRYPTSETUP_TRIALS -gt 0 ] || { ykfde_err 006 "YKFDE_CRYPTSETUP_TRIALS needs to be a number > 0."; return 1; }
 
-    [ $DBG ] && echo " > udevadm settle..."
+    [ "$DBG" ] && echo " > udevadm settle..."
     udevadm settle || { ykfde_err 004 "Failed to 'udevadm settle'"; return 1; }
 
-    [ $DBG ] && echo " > modprobe -a -q dm-crypt..."
+    [ "$DBG" ] && echo " > modprobe -a -q dm-crypt..."
     tmp="$(modprobe -a dm-crypt 2>&1)" || { ykfde_err 005 "FAILED to 'modprobe -a -q dm-crypt':\n$tmp"; return 1; }
 
     local trial_nr=1;
@@ -140,7 +140,7 @@ run_hook() {
     while [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ]; do
       printf "\nTRIAL #$trial_nr/$YKFDE_CRYPTSETUP_TRIALS: cryptsetup of $what\n"
       ykfde_do_it && return 0;
-      trial_nr=$(( $trial_nr + 1 ));
+      trial_nr=$(( trial_nr + 1 ));
     done
 
     # if we get here, we did NOT succeed:

--- a/src/install/ykfde
+++ b/src/install/ykfde
@@ -26,7 +26,8 @@ build() {
     add_binary "sleep"
     add_binary "printf"
     add_file "/etc/ykfde.conf" "/etc/ykfde.conf"
-
+    add_file "/usr/lib/ykfde-suspend/encrypt-on-suspend" "/bin" 755
+    
     add_runscript
 }
 

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Copyright 2013 Vianney le Clément de Saint-Marcq <vleclement@gmail.com>  
+# Copyright 2017 Zhongfu Li <me@zhongfu.li>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with This program.  If not, see http://www.gnu.org/licenses/.
+
+set -e -u
+trap 'echo "Press ENTER to continue."; read dummy' ERR
+trap cleanup EXIT
+
+################################################################################
+## Parameters and helper functions
+
+INITRAMFS_DIR=/run/initramfs
+SYSTEM_SLEEP_PATH=/usr/lib/systemd/system-sleep
+SYSTEM_SLEEP_BINARY=/lib/systemd/systemd-sleep
+SUSPEND_SCRIPT=bin/encrypt-on-suspend
+BIND_PATHS="/sys /proc /dev /run"
+REMOUNT=0
+# Retrieve cryptdevice name from /proc/mounts -- kinda hacky
+CRYPTNAME="$(grep -E "^/dev/mapper/[a-zA-Z0-9_\-]+ / " /proc/mounts | sed -r "s|^/dev/mapper/([a-zA-Z0-9_\-]+).*|\1|")"
+
+# run_dir DIR ARGS...
+# Run all executable scripts in directory DIR with arguments ARGS
+run_dir() {
+    local dir=$1
+    shift
+    find "${dir}" -type f -executable -exec "{}" "$@" ";"
+}
+
+# Remount root fs with barrier
+mount_barrier() {
+    if ((REMOUNT)); then
+        mount -o remount,barrier "/dev/mapper/$CRYPTNAME"
+        REMOUNT=0
+    fi
+}
+
+# Unmount bind mounts
+umount_bind() {
+    local p
+    for p in ${BIND_PATHS}; do
+        mountpoint -q "${INITRAMFS_DIR}${p}" && umount "${INITRAMFS_DIR}${p}"
+    done
+}
+
+# Unmount (and remove) extracted initramfs
+# umount -l (lazy) because sometimes, it takes a while before everything stops
+# using the ramdisk.
+umount_initramfs() {
+    mountpoint -q "${INITRAMFS_DIR}" && umount -l "${INITRAMFS_DIR}"
+}
+
+cleanup() {
+    mount_barrier
+    ((BIND_MOUNTED)) && umount_bind
+    umount_initramfs
+}
+
+cryptdevice_mount_options() {
+    local mt
+    mt="$(grep "^/dev/mapper/${1} " /proc/mounts | cut -d ' ' -f 3,4 | head -n 1)"
+    local fs
+    fs="$(cut -d ' ' -f 1 <<< "${mt}")"
+    local opt
+    opt="$(cut -d ' ' -f 2 <<< "${mt}")"
+    if [[ "${fs}" == "ext4" || "${fs}" == "btrfs" ]]; then
+        echo "${opt}"
+    fi
+}
+
+################################################################################
+## Main script
+
+[ -e "${INITRAMFS_DIR}/$SUSPEND_SCRIPT" ] || exec $SYSTEM_SLEEP_BINARY suspend
+
+# Prepare chroot
+trap umount_initramfs EXIT
+for p in ${BIND_PATHS}; do
+    mkdir -p "${INITRAMFS_DIR}${p}"
+    mount -o bind "${p}" "${INITRAMFS_DIR}${p}"
+done
+
+# Run pre-suspend scripts
+run_dir "${SYSTEM_SLEEP_PATH}" pre suspend
+
+# Stop udev service and prevent it from being autostarted.
+# Otherwise, luksResume will hang waiting for udev, which is itself waiting
+# for I/O on the root device.
+systemctl stop systemd-udevd-control.socket
+systemctl stop systemd-udevd-kernel.socket
+systemctl stop systemd-udevd.service
+
+# Stop systemd-journald and prevent it from being autostarted.
+# It seems to block suspend with file I/O
+systemctl stop systemd-journald-dev-log.socket
+systemctl stop systemd-journald.socket
+systemctl stop systemd-journald-audit.socket
+systemctl stop systemd-journald.service
+
+# Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
+# if mounted with `barrier=1`, which is the default. Temporarily remount with
+# `barrier=0` if this is true of the crypt fs.
+MOUNT_OPTS="$(cryptdevice_mount_options "$CRYPTNAME")"
+if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == *barrier=0* ]]; then
+    REMOUNT=1
+    mount -o remount,nobarrier "/dev/mapper/$CRYPTNAME"
+fi
+
+# Synchronize filesystems before luksSuspend
+sync
+
+# Hand over execution to script inside initramfs
+cd "${INITRAMFS_DIR}"
+chroot . /suspend "$CRYPTNAME"
+
+# Restore original mount options if necessary
+mount_barrier
+
+# Restart systemd-journald
+systemctl start systemd-journald-dev-log.socket
+systemctl start systemd-journald.socket
+systemctl start systemd-journald-audit.socket
+systemctl start systemd-journald.service
+
+# Restart udev
+systemctl start systemd-udevd-control.socket
+systemctl start systemd-udevd-kernel.socket
+systemctl start systemd-udevd.service
+
+# Run post-suspend scripts
+run_dir "${SYSTEM_SLEEP_PATH}" post suspend
+
+# Unlock user sessions
+loginctl unlock-sessions

--- a/src/ykfde-suspend.service
+++ b/src/ykfde-suspend.service
@@ -1,0 +1,20 @@
+#  This file has been adapted from systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Suspend
+Documentation=man:systemd-suspend.service(8)
+DefaultDependencies=no
+Requires=sleep.target
+After=sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/openvt -ws /usr/lib/ykfde-suspend/ykfde-suspend
+
+[Install]
+Alias=systemd-suspend.service


### PR DESCRIPTION
This PR fixes most issues detected by shellcheck static analysis tool 

https://www.shellcheck.net/
https://github.com/koalaman/shellcheck

```text
In ykfde line 11:
  printf "$msg"; #exit 1;
         ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ykfde line 24:
    [ $YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT -gt 0 ] && _yubikey_timeout_str="$YKFDE_CHALLENGE_YUBIKEY_INSERT_TIMEOUT seconds"
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 31:
      _endtime=$(date +%s); _usedtime=$(( $_endtime - $_starttime ));
                                          ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                                                      ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In ykfde line 36:
      printf "   Enter password: "; if [ $DBG ]; then read _pw; else read -s _pw; fi
                                         ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                      ^-- SC2162: read without -r will mangle backslashes.
                                                                     ^-- SC2162: read without -r will mangle backslashes.


In ykfde line 38:
      [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
        ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 41:
      [ $DBG ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
        ^-- SC2086: Double quote to prevent globbing and word splitting.
                         ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ykfde line 42:
      _tmp="$(ykinfo -$YKFDE_CHALLENGE_SLOT 2>&1)"; _rc=$?;
                      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 43:
      [ $DBG ] && echo "[$_rc] '$_tmp'"
        ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 45:
      if [ $_yubikey_timeout -eq -1 -o $_usedtime -le $_yubikey_timeout ]; then
           ^-- SC2086: Double quote to prevent globbing and word splitting.
                                    ^-- SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
                                                      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 53:
    [ $DBG ] && echo "   Running NOW: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 54:
    _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 57:
      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 61:
      _passphrase="$(ykchalresp -$YKFDE_CHALLENGE_SLOT "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 63:
    [ $DBG ] && printf "\n   Got as response: '$_passphrase'\n"
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                       ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ykfde line 65:
    if [ -n "$_passphrase" -a "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
                           ^-- SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.


In ykfde line 83:
          [ $trial_nr -le $YKFDE_CRYPTSETUP_TRIALS ] && echo "   Just press ENTER to skip and to try Challenge-Response again."
            ^-- SC2086: Double quote to prevent globbing and word splitting.
                          ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 88:
        printf "   Enter passphrase: "; if [ $DBG ]; then read _passphrase; else read -s _passphrase; fi
                                             ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                          ^-- SC2162: read without -r will mangle backslashes.
                                                                                 ^-- SC2162: read without -r will mangle backslashes.


In ykfde line 89:
        [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
          ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 94:
    [ $DBG ] && echo " > Using '$_passphrase' with cryptsetup!"
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 95:
    [ $DBG ] && echo " > Decrypting (cryptsetup luksOpen "$YKFDE_LUKS_DEV" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                          ^-- SC2027: The surrounding quotes actually unquote this. Remove or escape them.
                                                          ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 97:
    _tmp="$(printf "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
                   ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ykfde line 102:
        if [ -n "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP -gt 0 ]; then
                                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 103:
          [ $DBG ] && echo " > Sleeping $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP bevore moving on..."
            ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 104:
          sleep $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP
                ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 117:
    [ $DBG ] && echo "$0:"
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 119:
    [ $DBG ] && echo " > Reading YKFDE_CONFIG_FILE..."
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 120:
    . "$YKFDE_CONFIG_FILE" || { ykfde_err 001 "Failed reading YKFDE_CONFIG_FILE '$YKFDE_CONFIG_FILE'"; return 1; }
    ^-- SC1090: Can't follow non-constant source. Use a directive to specify location.


In ykfde line 122:
    [ -z "$YKFDE_DISK_UUID" -o -z "$YKFDE_LUKS_NAME" ] && { ykfde_err 002 "'$YKFDE_CONFIG_FILE' must provide YKFDE_DISK_UUID /and/ YKFDE_LUKS_NAME."; return 1; }
                            ^-- SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.


In ykfde line 132:
    [ $DBG ] && echo " > udevadm settle..."
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 135:
    [ $DBG ] && echo " > modprobe -a -q dm-crypt..."
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In ykfde line 139:
    local what="$YKFDE_DISK_UUID"; [ -n "$YKFDE_LUKS_NAME" ] && s=" $YKFDE_LUKS_NAME";
                                                                ^-- SC2034: s appears unused. Verify it or export it.


In ykfde line 141:
      printf "\nTRIAL #$trial_nr/$YKFDE_CRYPTSETUP_TRIALS: cryptsetup of $what\n"
             ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In ykfde line 143:
      trial_nr=$(( $trial_nr + 1 ));
                   ^-- SC2004: $/${} is unnecessary on arithmetic variables.

```