### PR TITLE
Hash password with sha256

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -34,6 +34,7 @@ ykfde_challenge_response() {
       echo " > Please provide password which will be used as challenge."
       while [ -z "$_pw" ]; do
       printf "   Enter password: "; if [ $DBG ]; then read _pw; else read -s _pw; fi
+      _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
       done
       [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
       YKFDE_CHALLENGE="$_pw"


### PR DESCRIPTION
Using password as challenge can have some drawbacks:

- Password can be very weak like "aaa"
- Password can be longer than 64 characters which is max for yubikey challenge which result in breakage.

As solution we can hash the password with sha256 which give us 64 characters (maximum) length challenge for any user provided password.

In result we have 104 (64+40) characters long LUKS passphrase