### PR TITLE
Fix suspend + various improvements

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -95,9 +95,13 @@ ykfde_do_it() {
     [ -e "$YKFDE_LUKS_DEV" ] || { ykfde_err 003 "YKFDE cannot find LUKS device '$YKFDE_LUKS_DEV'.\nPlease check YKFDE_DISK_UUID ($YKFDE_DISK_UUID) and/or YKFDE_LUKS_DEV variable(s) in '$YKFDE_CONFIG_FILE'."; return 1; }
 
     [ "$DBG" ] && echo " > Passing '$_passphrase' to cryptsetup!"
-    [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
-
-    _tmp="$(printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
+    if [ -n "$RESUME" ]; then
+        [ "$DBG" ] && echo " > Decrypting (cryptsetup luksResume \"$cryptname\"..." || echo " > Decrypting (cryptsetup luksResume)..."
+        _tmp="$(printf %s "$_passphrase"| cryptsetup luksResume "${cryptname}" 2>&1;)";
+    else
+        [ "$DBG" ] && echo " > Decrypting (cryptsetup luksOpen \"$YKFDE_LUKS_DEV\" \"$YKFDE_LUKS_NAME\")..." || echo " > Decrypting (cryptsetup luksOpen)..."
+        _tmp="$(printf %s "$_passphrase"| cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" 2>&1)";
+    fi
     _rc=$?;
 
     if [ $_rc -eq 0 ]; then
@@ -130,13 +134,10 @@ run_hook() {
     [ -z "$YKFDE_CRYPTSETUP_TRIALS" ] && YKFDE_CRYPTSETUP_TRIALS="$DEFAULT_CRYPTSETUP_TRIALS"
 
     # sanity checks:
-    [ $YKFDE_CRYPTSETUP_TRIALS -gt 0 ] || { ykfde_err 006 "YKFDE_CRYPTSETUP_TRIALS needs to be higher than 0."; return 1; }
-
-    [ "$DBG" ] && echo " > Settling udevadm."
-    udevadm settle || { ykfde_err 004 "Failed to settle udevadm."; return 1; }
+    [ $YKFDE_CRYPTSETUP_TRIALS -gt 0 ] || { ykfde_err 004 "YKFDE_CRYPTSETUP_TRIALS needs to be higher than 0."; return 1; }
 
     [ "$DBG" ] && echo " > modprobing dm-crypt"
-    tmp="$(modprobe -a dm-crypt 2>&1)" || { ykfde_err 005 "Failed executing 'modprobe -a -q dm-crypt':\n$tmp"; return 1; }
+    _tmp="$(modprobe -a -q dm-crypt >/dev/null 2>&1)"
 
     local trial_nr=1;
     local what="$YKFDE_DISK_UUID"; [ -n "$YKFDE_LUKS_NAME" ] && s=" $YKFDE_LUKS_NAME";

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/ash
 
 YKFDE_CONFIG_FILE="/etc/ykfde.conf"
 

--- a/src/initramfs-suspend
+++ b/src/initramfs-suspend
@@ -15,46 +15,9 @@ sync
 echo mem > /sys/power/state
 
 # Resume root device
-. /etc/ykfde.conf
+RESUME=1
 
-
-[ -z "${cryptname}" ] ||
-    while true; do
-        if [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-            echo " > Please provide the challenge password."
-            while [ -z "$_pw" ]; do
-            printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
-            _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
-            done
-            [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
-            YKFDE_CHALLENGE="$_pw"
-        fi
-
-        [ "$DBG" ] && printf "   ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
-        _tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)";
-        [ "$DBG" ] && echo "$_tmp"
-        [ "$DBG" ] && echo "   Running: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
-        _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
-        if [ -z "$_passphrase" ]; then
-            printf "\n   Yubikey did not provide a response - Initializing second attempt, touch the device if necessary.\n"
-            _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
-        fi
-
-        if [ -z "$_passphrase" ]; then
-            printf "\n   Yubikey did not provide a response - Initializing second attempt, touch the device if necessary.\n"
-            _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
-        fi
-        [ "$DBG" ] && printf "\n   Received response: '$_passphrase'\n"
-
-        if [ -n "$_passphrase" ] && [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" = "1" ]; then
-            _passphrase="$_pw$_passphrase"
-        fi
-        [ "$DBG" ] && echo " > Passing '$_passphrase' to cryptsetup!"
-        [ "$DBG" ] && echo " > Decrypting (cryptsetup luksResume \"${cryptname}\")..." || echo " > Decrypting (cryptsetup luksResume)..."
-        printf %s "$_passphrase"| cryptsetup luksResume "${cryptname}" 2>&1;
-        [ $? -le 1 ] && break
-        sleep 2
-    done
+. /hooks/ykfde; run_hook
 
 # Stop udev from initramfs, as the real daemon from rootfs will be restarted
 udevadm control --exit

--- a/src/install/ykfde
+++ b/src/install/ykfde
@@ -3,13 +3,13 @@
 build() {
     local mod
 
-    add_module dm-crypt
+    add_module "dm-crypt"
     if [[ $CRYPTO_MODULES ]]; then
         for mod in $CRYPTO_MODULES; do
             add_module "$mod"
         done
     else
-        add_all_modules '/crypto/'
+        add_all_modules "/crypto/"
     fi
 
     add_binary "cryptsetup"
@@ -18,9 +18,9 @@ build() {
     add_file "/usr/lib/udev/rules.d/13-dm-disk.rules"
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
     add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
-    
+
     # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
-    add_file "/usr/lib/libgcc_s.so.1"
+    add_binary "/usr/lib/libgcc_s.so.1"
 
     add_binary "tr"
     add_binary "ykchalresp"
@@ -29,7 +29,7 @@ build() {
     add_binary "sleep"
     add_binary "printf"
     add_file "/etc/ykfde.conf" "/etc/ykfde.conf"
-    add_file "/usr/lib/ykfde-suspend/initramfs-suspend" "/bin/suspend" 755
+    add_file "/usr/lib/ykfde-suspend/initramfs-suspend" "/ykfde-suspend" 755
 
     add_runscript
 }

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -81,7 +81,7 @@ sync
 
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
-chroot . /bin/suspend "$CRYPTNAME"
+chroot . /ykfde-suspend "$CRYPTNAME"
 
 # Restore original mount options if necessary
 if ((REMOUNT)); then

--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u
 trap 'echo "Press ENTER to continue."; read dummy' ERR
@@ -44,7 +44,7 @@ cryptdevice_mount_options() {
 ################################################################################
 ## Main script
 
-[ -e "${INITRAMFS_DIR}/bin/suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
+[ -e "${INITRAMFS_DIR}/ykfde-suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
 
 # Prepare chroot
 trap umount_initramfs EXIT
@@ -64,6 +64,7 @@ systemctl stop systemd-udevd.service
 
 systemctl stop systemd-journald.socket
 systemctl stop systemd-journald-dev-log.socket
+systemctl stop systemd-journald-audit.socket
 systemctl stop systemd-journald.service
 
 # Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
@@ -88,6 +89,7 @@ if ((REMOUNT)); then
 fi
 
 systemctl start systemd-journald.service
+systemctl start systemd-journald-audit.socket
 systemctl start systemd-journald-dev-log.socket
 systemctl start systemd-journald.socket
 

--- a/src/ykfde-suspend.service
+++ b/src/ykfde-suspend.service
@@ -14,7 +14,7 @@ After=sleep.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/openvt -ws /usr/lib/ykfde-suspend/ykfde-suspend
+ExecStart=/usr/bin/openvt -ws -- /usr/lib/ykfde-suspend/ykfde-suspend
 
 [Install]
 Alias=systemd-suspend.service


### PR DESCRIPTION
Currently `suspend` hook is inferior in comparison to `boot` one. This PR make them equal. See https://github.com/agherzan/yubikey-full-disk-encryption/issues/21 for more info.

It also make various minor improvements:

- sync our hook with latest Archlinux encrypt hook changes
- remove duplication with udev hook (udevadm)
- use correct shell in initramfs, etc.

It's tested by myself and https://github.com/VGrol