### PR TITLE
Introduce ykfde-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
+	install -Dm755 src/ykfde-format "$(DESTDIR)/usr/bin/ykfde-format"
 	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
 reinstall:
 	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
@@ -14,6 +15,7 @@ reinstall:
 	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
 	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
 	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
+	install -Dm755 src/ykfde-format "$(DESTDIR)/usr/bin/ykfde-format"
 	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
 test:
 	./testrun.sh

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This password will never be stored and you will have to provide it everytime you
 ```
 CHALLENGE=5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
 RESPONSE=bd438575f4e8df965c80363f8aa6fe1debbe9ea9
-LUKS passphrase=5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8bd438575f4e8df965c80363f8aa6fe1debbe9ea9
+LUKS PASSPHRASE=5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8bd438575f4e8df965c80363f8aa6fe1debbe9ea9
 ```
 
 This strong passphrase cannot be broken by bruteforce. To recreate it one would need both your password (something you know) and your yubikey (something you have) which means it's real 2FA.
@@ -89,6 +89,11 @@ As root using cryptsetup:
 ykfde-open -d /dev/<device> -n <container_name>
 ```
 
+For formating new device, you can use ykfde-format script which is wrapper over "cryptsetup luksFormat" command.
+```
+ykfde-format --cipher aes-xts-plain64 --key-size 512 --hash sha256 --iter-time 5000 /dev/<device>
+```
+
 ## Initramfs hooks instalation and configuration
 
 Install all the needed scripts by issuing:
@@ -138,6 +143,7 @@ systemctl enable ykfde-suspend.service
 * Added ykfde-open and ykfde-enroll scripts
 * Added design information in Readme
 * Added udisksctl support
+* Added ykfde-format script
 
 ## Security
 

--- a/src/ykfde-enroll
+++ b/src/ykfde-enroll
@@ -94,7 +94,13 @@ fi
 [ "$DBG" ] && printf '%s\n' " > Using '$_passphrase' with cryptsetup!"
 echo "If prompted for a passphrase, enter the current passphrase for the LUKS container. This is the old LUKS passphrase."
 printf " Enter password: "; if [ "$DBG" ]; then read -r OLD; else read -r -s OLD; fi
-[ "$DBG" ] && echo " > Adding new LUKS key (cryptsetup --key-slot=\"$KEY_SLOT\" luksAddKey \"$YKFDE_LUKS_DEV\")..." || printf "\\n > Decrypting (cryptsetup luksAddKey)...\\n"
-printf '%s\n' "$OLD" "$_passphrase" "$_passphrase" | cryptsetup --key-slot="$KEY_SLOT" luksAddKey "$YKFDE_LUKS_DEV" 2>&1;
+
+if [ -n "$_passphrase" ]; then
+    [ "$DBG" ] && echo " > Adding new LUKS key (cryptsetup --key-slot=\"$KEY_SLOT\" luksAddKey \"$YKFDE_LUKS_DEV\")..." || printf "\\n > Decrypting (cryptsetup luksAddKey)...\\n"
+    printf '%s\n' "$OLD" "$_passphrase" "$_passphrase" | cryptsetup --key-slot="$KEY_SLOT" luksAddKey "$YKFDE_LUKS_DEV" 2>&1;
+else
+    echo "   Passphrase is empty. Operation aborted."
+    exit 1
+fi
 
 exit 0

--- a/src/ykfde-format
+++ b/src/ykfde-format
@@ -40,7 +40,12 @@ if [ -n "$_passphrase" ] && [ -n "$YKFDE_CHALLENGE_PASSWORD_NEEDED" ]; then
     _passphrase="$_pw$_passphrase"
 fi
 
-[ "$DBG" ] && printf '%s\n' " > Using '$_passphrase' with cryptsetup!"
-printf '%s\n' "$_passphrase" | cryptsetup luksFormat "$@" 2>&1;
+if [ -n "$_passphrase" ]; then
+    [ "$DBG" ] && printf '%s\n' " > Using '$_passphrase' with cryptsetup!"
+    printf '%s\n' "$_passphrase" | cryptsetup luksFormat "$@"
+else
+    echo "   Passphrase is empty. Operation aborted."
+    exit 1
+fi
 
 exit 0

--- a/src/ykfde-format
+++ b/src/ykfde-format
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+. /etc/ykfde.conf
+
+printf '%s\n' "This script will run 'cryptsetup luksFormat $*'.  If this is not what you intended, please abort."
+
+if [ -n "$YKFDE_CHALLENGE_PASSWORD_NEEDED" ]; then
+    echo " > Please provide the challenge password."
+    while [ -z "$_pw" ]; do
+    printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw; else read -r -s _pw; fi
+    printf "\\n > Please repeat the password.\\n"
+    printf "   Enter password: "; if [ "$DBG" ]; then read -r _pw2; else read -r -s _pw2; fi
+    if [ "$_pw" != "$_pw2" ]; then
+	echo "Passwords do not match."
+	exit 1
+    fi
+    _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+    done
+    [ "$DBG" ] || echo # if /NOT/ DBG, we need to output \n here.
+    YKFDE_CHALLENGE="$_pw"
+fi
+
+[ "$DBG" ] && printf %s "   ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "
+_tmp="$(ykinfo -"$YKFDE_CHALLENGE_SLOT" 2>&1)";
+[ "$DBG" ] && printf '%s\n' "$_tmp"
+
+echo "   Remember to touch the device if necessary."
+[ "$DBG" ] && printf '%s\n' "   Running: ykchalresp -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\"..."
+_passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+
+if [ -z "$_passphrase" ]; then
+    echo "   Yubikey did not provide a response - Initializing second attempt, touch the device if necessary."
+    _passphrase="$(ykchalresp -"$YKFDE_CHALLENGE_SLOT" "$YKFDE_CHALLENGE" 2>/dev/null| tr -d '\n')"
+fi
+
+[ "$DBG" ] && printf '%s\n' "   Received response: '$_passphrase'"
+
+if [ -n "$_passphrase" ] && [ -n "$YKFDE_CHALLENGE_PASSWORD_NEEDED" ]; then
+    _passphrase="$_pw$_passphrase"
+fi
+
+[ "$DBG" ] && printf '%s\n' " > Using '$_passphrase' with cryptsetup!"
+printf '%s\n' "$_passphrase" | cryptsetup luksFormat "$@" 2>&1;
+
+exit 0


### PR DESCRIPTION
This will add missing piece in our scripts: ability to create new containers with yubikey challenge-response passphrase used by default.

We already cover adding passphrases to existing containers and opening created containers so this will be nice addition.