### PR TITLE
fix reinstall target and backup config if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-install:
-	install -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+install: reinstall
+	install -v -b -Dm644 src/ykfde.conf "$(DESTDIR)/etc/ykfde.conf"
+
+reinstall:
 	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks/ykfde"
 	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install/ykfde"
 	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-suspend"
@@ -8,14 +10,7 @@ install:
 	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
 	install -Dm755 src/ykfde-format "$(DESTDIR)/usr/bin/ykfde-format"
 	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
-reinstall:
-	install -Dm644 src/hooks/ykfde "$(DESTDIR)/usr/lib/initcpio/hooks"
-	install -Dm644 src/install/ykfde "$(DESTDIR)/usr/lib/initcpio/install"
-	install -Dm755 src/ykfde-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/ykfde-luks-suspend"
-	install -Dm755 src/initramfs-suspend "$(DESTDIR)/usr/lib/ykfde-suspend/initramfs-suspend"
-	install -Dm644 src/ykfde-suspend.service "$(DESTDIR)/usr/lib/systemd/system/ykfde-suspend.service"
-	install -Dm755 src/ykfde-enroll "$(DESTDIR)/usr/bin/ykfde-enroll"
-	install -Dm755 src/ykfde-format "$(DESTDIR)/usr/bin/ykfde-format"
-	install -Dm755 src/ykfde-open "$(DESTDIR)/usr/bin/ykfde-open"
 test:
 	./testrun.sh
+
+all: install


### PR DESCRIPTION
also add default target and remove code duplication in
install/reinstall targets. reinstall target was not in sync with install
target and caused me some trouble on finding issues with ykfde-suspend
which has been renamed.