### PR TITLE
Add option for testing passphrase and key slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ To print only the ykfde passphrase to the console without unlocking any volumes:
 ykfde-open -p
 ```
 
+To test only a passphrase for a specific key slot:
+
+```
+ykfde-open -d /dev/<device> -s <keyslot_number> -t
+```
+
 ## Killing ykfde passphrase for existing LUKS encrypted volume
 
 To kill a ykfde passphrase for existing *LUKS* encrypted volume you can use [ykfde-enroll](https://github.com/agherzan/yubikey-full-disk-encryption/blob/master/src/ykfde-enroll) script, see `ykfde-enroll -h` for help:

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # sanitize environment
 YKFDE_LUKS_DEV=""
+LUKS_KEYSLOT=""
 YKFDE_LUKS_NAME=""
 YKFDE_PRINT_ONLY=""
 YKFDE_MOUNT=""
@@ -15,6 +16,7 @@ YKFDE_CHALLENGE=""
 YKFDE_RESPONSE=""
 YKFDE_PASSPHRASE=""
 YKFDE_LUKS_OPTIONS=""
+TEST_PASSPHRASE=""
 
 if [ -r /etc/ykfde.conf ]; then
   # shellcheck source=ykfde.conf
@@ -23,11 +25,20 @@ else
   echo "WARNING: Can't access /etc/ykfde.conf. Falling back to defaults."
 fi
 
-while getopts ":d:n:pmvh" opt; do
+while getopts ":d:s:n:pmtvh" opt; do
   case "$opt" in
     d)
       YKFDE_LUKS_DEV="$OPTARG"
       printf '%s\n' "INFO: Setting device to '$OPTARG'."
+      ;;
+    s)
+      if [ "$OPTARG" -gt -8 ] && [ "$OPTARG" -lt 8 ]; then
+        LUKS_KEYSLOT="$OPTARG"
+        printf '%s\n' "INFO: Setting LUKS keyslot to '$OPTARG'."
+      else
+        printf '%s\n' "ERROR: Chosen LUKS keyslot '$OPTARG' is invalid. Please choose valid LUKS keyslot number between '0-7'."
+        exit 1
+      fi
       ;;
     n)
       YKFDE_LUKS_NAME="$OPTARG"
@@ -41,6 +52,10 @@ while getopts ":d:n:pmvh" opt; do
       YKFDE_MOUNT=1
       echo "INFO: Mounting device"
       ;;
+    t)
+      TEST_PASSPHRASE="--test-passphrase"
+      echo "INFO: Testing LUKS passphrase"
+      ;;
     v)
       DBG=1
       echo "INFO: Debugging enabled"
@@ -48,9 +63,11 @@ while getopts ":d:n:pmvh" opt; do
     h)
       echo
       echo " -d <device>   : select an existing device"
+      echo " -s <slot>     : select the LUKS keyslot"
       echo " -n <name>     : set the new encrypted volume name"
       echo " -p            : show cleartext ykfde passphrase without unlocking"
       echo " -m            : mount unlocked device (non root user only)"
+      echo " -t            : test LUKS passphrase"
       echo " -v            : show input/output in cleartext"
       echo
       exit 1
@@ -59,9 +76,11 @@ while getopts ":d:n:pmvh" opt; do
       printf '%s\n' "Error: Invalid option: '-$OPTARG'" >&2
       echo
       echo " -d <device>   : select an existing device"
+      echo " -s <slot>     : select the LUKS keyslot"
       echo " -n <name>     : set the new encrypted volume name"
       echo " -p            : show cleartext ykfde passphrase without unlocking"
       echo " -m            : mount unlocked device (non root user only)"
+      echo " -t            : test LUKS passphrase"
       echo " -v            : show input/output in cleartext"
       echo
       exit 1
@@ -97,6 +116,10 @@ if [ -z "$YKFDE_PRINT_ONLY" ]; then
     fi
   fi
   printf '%s\n' "WARNING: This script will try to open the '$YKFDE_LUKS_NAME' LUKS encrypted volume on drive '$YKFDE_LUKS_DEV' . If this is not what you intended, please abort."
+fi
+
+if [ "$LUKS_KEYSLOT" ]; then
+  LUKS_KEYSLOT="--key-slot=$LUKS_KEYSLOT"
 fi
 
 [ -z "$YKFDE_CHALLENGE" ] && YKFDE_CHALLENGE_PASSWORD_NEEDED=1
@@ -137,10 +160,18 @@ if [ "$YKFDE_PRINT_ONLY" ]; then
   exit 0
 fi
 
+if [ "$TEST_PASSPHRASE" ]; then
+  [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $TEST_PASSPHRASE $YKFDE_LUKS_DEV $LUKS_KEYSLOT'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$TEST_PASSPHRASE" "$YKFDE_LUKS_DEV" "$LUKS_KEYSLOT" 2>&1
+  printf '%s\n' "   Device successfully opened"
+  exit 0
+fi
+
 if [ "$(id -u)" -eq 0 ]; then
   [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
-  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS'..." || echo " > Decrypting with 'cryptsetup'..."
-  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" 2>&1
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $LUKS_KEYSLOT'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$LUKS_KEYSLOT" 2>&1
   printf '%s\n' "   Device successfully opened as '/dev/mapper/$YKFDE_LUKS_NAME'"
 elif [ ! -b "$YKFDE_LUKS_DEV" ]; then
   # udisks doesn't work with regular file based devies


### PR DESCRIPTION
I found it useful to test which YubiKey belongs to which LUKS key slot. `-s` is a common option, because it can be used to open the device with this specific slot.