### PR TITLE
Look for plymouth in the right location

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -31,7 +31,7 @@ run_hook() {
   _tmp=""
   local cryptopt cryptoptions
 
-  [ -x /bin/plymouth ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
+  [ -x /usr/bin/plymouth ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
 
   [ "$DBG" ] && message "$0:"
 


### PR DESCRIPTION
Currently, this hook searches for plymouth in `/bin`, but it lives in `/usr/bin`.