### PR TITLE
Fix asking for passphrase twice if splash isn't enabled.

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -31,7 +31,7 @@ run_hook() {
   _tmp=""
   local cryptopt cryptoptions
 
-  [ -x /bin/plymouth ] && [ $splash] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
+  [ -x /bin/plymouth ] && [ $splash ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
 
   [ "$DBG" ] && message "$0:"
 

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -31,7 +31,7 @@ run_hook() {
   _tmp=""
   local cryptopt cryptoptions
 
-  [ -x /bin/plymouth ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
+  [ -x /bin/plymouth ] && [ $splash] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
 
   [ "$DBG" ] && message "$0:"
 

--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -31,7 +31,7 @@ run_hook() {
   _tmp=""
   local cryptopt cryptoptions
 
-  [ -x /bin/plymouth ] && [ $splash ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
+  [ -x /bin/plymouth ] && [ "$splash" ] && plymouth --ping && YKFDE_USE_PLYMOUTH=1
 
   [ "$DBG" ] && message "$0:"
 


### PR DESCRIPTION
I'm using systemd-boot and the latest Arch and have 2 bootloader entries. One launches a graphical session by using the systemd.unit=graphical.target kernel parameter and includes kernel  parameters for quieter booting with splash and plymouth. The other launches a consol session by using the systemd.unit=multi-user.target and omits the splash parameter.

When using the entry for console booting, plymouth graphical display doesn't load but messages are still passed from ykfde to plymouth, as a result I'm prompted for my passphrase twice: first by ykfde then by plymouth. Unlike the filed issue with getting 2 prompts when using GRUB followed by an error that the container is already decrypted, I only enter my passphrase once and everything works. I believe there should still be only one prompt though. Outdated information for older versions of plymouth implied a kernel parameter plymouth.enable=0 to disable it, which I was hoping would've stopped plymouthd and caused ykfde to not prompt through the plymouth text mode when the ping fails, but it seems to no longer work and I find no reference to it in the plymouth source.

This PR solution is just changing the check for plymouth to include ensuring the splash kernel parameter has been passed. It's been tested with systemd-boot on Arch and it works fine for me: suppressing the plymouth text prompt when the splash kernel parameter isn't passed, and enabling it when it has.