### PR TITLE
Allow custom params to ykfde-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ To test only a passphrase for a specific key slot:
 ykfde-open -d /dev/<device> -s <keyslot_number> -t
 ```
 
+To use optional parameters, example, use an external luks header:
+
+```
+ykfde-open -d /dev/<device> -- --header /mnt/luks-header.img
+```
+
 ## Kill ykfde passphrase for existing LUKS encrypted volume
 
 To kill a ykfde passphrase for existing *LUKS* encrypted volume you can use [ykfde-enroll](https://github.com/agherzan/yubikey-full-disk-encryption/blob/master/src/ykfde-enroll) script, see `ykfde-enroll -h` for help:

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -89,6 +89,8 @@ while getopts ":d:s:n:pmtvh" opt; do
   esac
 done
 
+shift $((OPTIND -1))
+
 YKFDE_SLOT_CHECK="$(ykinfo -q -"$YKFDE_CHALLENGE_SLOT")"
 [ "$DBG" ] && printf '%s\n' " > YubiKey slot status 'ykinfo -q -$YKFDE_CHALLENGE_SLOT': $YKFDE_SLOT_CHECK"
 
@@ -107,7 +109,7 @@ if [ -z "$YKFDE_PRINT_ONLY" ]; then
     exit 1
   fi
   if [ "$(id -u)" -eq 0 ]; then
-    if ! cryptsetup isLuks "$YKFDE_LUKS_DEV"; then
+    if ! cryptsetup isLuks "$YKFDE_LUKS_DEV" "$@"; then
       printf '%s\n' "ERROR: Selected device '$YKFDE_LUKS_DEV' isn't a LUKS encrypted volume. Please select a valid device."
       exit 1
     fi
@@ -157,16 +159,16 @@ fi
 
 if [ "$YKFDE_TEST_PASSPHRASE" ]; then
   [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
-  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_TEST_PASSPHRASE $YKFDE_LUKS_DEV $YKFDE_LUKS_KEYSLOT'..." || echo " > Decrypting with 'cryptsetup'..."
-  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_TEST_PASSPHRASE" "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_KEYSLOT" 2>&1
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_TEST_PASSPHRASE $YKFDE_LUKS_DEV $YKFDE_LUKS_KEYSLOT $@'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_TEST_PASSPHRASE" "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_KEYSLOT" "@" 2>&1
   printf '%s\n' "   Device successfully opened"
   exit 0
 fi
 
 if [ "$(id -u)" -eq 0 ]; then
   [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
-  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $YKFDE_LUKS_KEYSLOT'..." || echo " > Decrypting with 'cryptsetup'..."
-  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$YKFDE_LUKS_KEYSLOT" 2>&1
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $YKFDE_LUKS_KEYSLOT $@'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$YKFDE_LUKS_KEYSLOT" "$@" 2>&1
   printf '%s\n' "   Device successfully opened as '/dev/mapper/$YKFDE_LUKS_NAME'"
 elif [ ! -b "$YKFDE_LUKS_DEV" ]; then
   # udisks doesn't work with regular file based devies

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -63,33 +63,35 @@ while getopts ":d:s:n:pmtvh" opt; do
       ;;
     h)
       echo
-      echo " -d <device>   : select an existing device"
-      echo " -s <slot>     : select the LUKS keyslot"
-      echo " -n <name>     : set the new encrypted volume name"
-      echo " -p            : show cleartext ykfde passphrase without unlocking"
-      echo " -m            : mount unlocked device (non root user only)"
-      echo " -t            : test LUKS passphrase"
-      echo " -v            : show input/output in cleartext"
+      echo " -d <device>     : select an existing device"
+      echo " -s <slot>       : select the LUKS keyslot"
+      echo " -n <name>       : set the new encrypted volume name"
+      echo " -p              : show cleartext ykfde passphrase without unlocking"
+      echo " -m              : mount unlocked device (non root user only)"
+      echo " -t              : test LUKS passphrase"
+      echo " -v              : show input/output in cleartext"
+      echo " [ -- --params ] : pass optional cryptsetup luksOpen parameters"
       echo
       exit 0
       ;;
     \?)
       printf '%s\n' "ERROR: Invalid option: '-$OPTARG'" >&2
       echo
-      echo " -d <device>   : select an existing device"
-      echo " -s <slot>     : select the LUKS keyslot"
-      echo " -n <name>     : set the new encrypted volume name"
-      echo " -p            : show cleartext ykfde passphrase without unlocking"
-      echo " -m            : mount unlocked device (non root user only)"
-      echo " -t            : test LUKS passphrase"
-      echo " -v            : show input/output in cleartext"
+      echo " -d <device>     : select an existing device"
+      echo " -s <slot>       : select the LUKS keyslot"
+      echo " -n <name>       : set the new encrypted volume name"
+      echo " -p              : show cleartext ykfde passphrase without unlocking"
+      echo " -m              : mount unlocked device (non root user only)"
+      echo " -t              : test LUKS passphrase"
+      echo " -v              : show input/output in cleartext"
+      echo " [ -- --params ] : pass optional cryptsetup luksOpen parameters"
       echo
       exit 1
       ;;
   esac
 done
 
-shift $((OPTIND -1))
+shift "$((OPTIND -1))"
 
 YKFDE_SLOT_CHECK="$(ykinfo -q -"$YKFDE_CHALLENGE_SLOT")"
 [ "$DBG" ] && printf '%s\n' " > YubiKey slot status 'ykinfo -q -$YKFDE_CHALLENGE_SLOT': $YKFDE_SLOT_CHECK"
@@ -159,16 +161,16 @@ fi
 
 if [ "$YKFDE_TEST_PASSPHRASE" ]; then
   [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
-  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_TEST_PASSPHRASE $YKFDE_LUKS_DEV $YKFDE_LUKS_KEYSLOT $@'..." || echo " > Decrypting with 'cryptsetup'..."
-  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_TEST_PASSPHRASE" "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_KEYSLOT" "@" 2>&1
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_TEST_PASSPHRASE $YKFDE_LUKS_DEV $YKFDE_LUKS_KEYSLOT $*'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_TEST_PASSPHRASE" "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_KEYSLOT" "$*" 2>&1
   printf '%s\n' "   Device successfully opened"
   exit 0
 fi
 
 if [ "$(id -u)" -eq 0 ]; then
   [ "$DBG" ] && printf '%s\n' " > Passing '$YKFDE_PASSPHRASE' to 'cryptsetup'"
-  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $YKFDE_LUKS_KEYSLOT $@'..." || echo " > Decrypting with 'cryptsetup'..."
-  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$YKFDE_LUKS_KEYSLOT" "$@" 2>&1
+  [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $YKFDE_LUKS_KEYSLOT $*'..." || echo " > Decrypting with 'cryptsetup'..."
+  printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$YKFDE_LUKS_KEYSLOT" "$*" 2>&1
   printf '%s\n' "   Device successfully opened as '/dev/mapper/$YKFDE_LUKS_NAME'"
 elif [ ! -b "$YKFDE_LUKS_DEV" ]; then
   # udisks doesn't work with regular file based devies


### PR DESCRIPTION
Hi,

Thanks for this project,

I'm trying to use luks detached header, and so come this little patch.

This add the support of misc parameters to ykfde-open. This is already good for ykfde-format.

Example: 

* To be able to use a detached header:

```
ykfde-open -d /dev/sda2 -n luks -- --header /dev/sdb1
```

We can also pass more luks parameters if needed.

Regards