### PR TITLE
ykfde-open: make udisksctl and expect optional

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,8 +6,10 @@ pkgdesc='Use YubiKey to unlock a LUKS partition'
 arch=('any')
 url='https://github.com/agherzan/yubikey-full-disk-encryption'
 license=('Apache')
-depends=('yubikey-personalization' 'cryptsetup' 'udisks2' 'expect')
-optdepends=('ykchalresp-nfc: NFC support')
+depends=('yubikey-personalization' 'cryptsetup')
+optdepends=('ykchalresp-nfc: NFC support'
+            'udisks2: use ykfde-open without root'
+            'expect: use ykfde-open without root')
 makedepends=('git')
 backup=('etc/ykfde.conf')
 source=('git+https://github.com/agherzan/yubikey-full-disk-encryption.git')

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ As unprivileged user using udisksctl (recommended):
 ykfde-open -d /dev/<device>
 ```
 
-As root using cryptsetup (when udisks is not available):
+As root using cryptsetup (when [udisks2](https://www.archlinux.org/packages/extra/x86_64/udisks2/) or [expect](https://www.archlinux.org/packages/extra/x86_64/expect/) aren't available):
 
 ```
 ykfde-open -d /dev/<device> -n <volume_name>

--- a/src/ykfde-open
+++ b/src/ykfde-open
@@ -172,6 +172,9 @@ if [ "$(id -u)" -eq 0 ]; then
   [ "$DBG" ] && printf '%s\n' " > Decrypting with 'cryptsetup luksOpen $YKFDE_LUKS_DEV $YKFDE_LUKS_NAME $YKFDE_LUKS_OPTIONS $YKFDE_LUKS_KEYSLOT $*'..." || echo " > Decrypting with 'cryptsetup'..."
   printf %s "$YKFDE_PASSPHRASE" | cryptsetup luksOpen "$YKFDE_LUKS_DEV" "$YKFDE_LUKS_NAME" "$YKFDE_LUKS_OPTIONS" "$YKFDE_LUKS_KEYSLOT" "$*" 2>&1
   printf '%s\n' "   Device successfully opened as '/dev/mapper/$YKFDE_LUKS_NAME'"
+elif ! command -v udisksctl >/dev/null 2>&1 || ! command -v expect >/dev/null 2>&1; then
+  printf '%s\n' "ERROR: At least one of required tools 'udisksctl' or 'expect' cannot be found. Please install 'udisks2' and 'expect' packages or use 'cryptsetup' by executing this script as 'root'."
+  exit 1
 elif [ ! -b "$YKFDE_LUKS_DEV" ]; then
   # udisks doesn't work with regular file based devies
   printf '%s\n' "ERROR: Selected device '$YKFDE_LUKS_DEV' isn't a block device file. Please open it with 'cryptsetup' by executing this script as 'root'."


### PR DESCRIPTION
This minimizes dependencies for users who aren't interested in
unprivileged usage of ykfde-open.

Fixes https://github.com/agherzan/yubikey-full-disk-encryption/issues/70