### PR TITLE
Lazy unmounting for initramfs

### DIFF
--- a/src/ykfde-suspend
+++ b/src/ykfde-suspend
@@ -29,7 +29,7 @@ run_dir() {
 umount_initramfs() {
   local p
   for p in "${BIND_PATHS[@]}"; do
-    ! mountpoint -q "$INITRAMFS_DIR$p" || umount "$INITRAMFS_DIR$p"
+    ! mountpoint -q "$INITRAMFS_DIR$p" || umount -l "$INITRAMFS_DIR$p"
   done
 }
 


### PR DESCRIPTION
![Previous bad unmounting](https://user-images.githubusercontent.com/25272468/118702632-76aff880-b815-11eb-82cb-241486a5e6c0.png)
As mentioned in #81, sometimes mounts are busy during the unmounting of the initramfs. Adding lazy unmounting to prevent theses problems.