### PR TITLE
Add silent fail feature

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -120,8 +120,13 @@ ykfde_do_it() {
 
   if [ -z "$_ykfde_passphrase" ]; then
     if [ "$YKFDE_CHALLENGE" ] || [ "$YKFDE_CHALLENGE_PASSWORD_NEEDED" ]; then
-      message " > Challenge-Response failed. Falling back to manual passphrase."
-      [ "$trial_nr" -le "$YKFDE_CRYPTSETUP_TRIALS" ] && message "   Press ENTER to skip and retry Challenge-Response."
+       if [ "$YKFDE_CHALLENGE_SILENT_FAIL" ]; then
+        message " > Challenge-Response failed. Skipping decryption."
+        return 0
+      else
+        message " > Challenge-Response failed. Falling back to manual passphrase."
+        [ "$trial_nr" -le "$YKFDE_CRYPTSETUP_TRIALS" ] && message "   Press ENTER to skip and retry Challenge-Response."
+      fi
     else
       message " > Passphrase needed to unlock device."
     fi

--- a/src/ykfde.conf
+++ b/src/ykfde.conf
@@ -48,6 +48,10 @@
 # Defaults to empty, meaning NO wait.
 #YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP=""
 
+# Silent fail after timeout
+# Leave empty to fallback to manual passphrase
+YKFDE_CHALLENGE_SILENT_FAIL="y"
+
 # Verbose output. It will print all secrets to terminal.
 # Use only for debugging.
 #DBG="1"

--- a/src/ykfde.conf
+++ b/src/ykfde.conf
@@ -50,7 +50,7 @@
 
 # Silent fail after timeout
 # Leave empty to fallback to manual passphrase
-YKFDE_CHALLENGE_SILENT_FAIL="y"
+#YKFDE_CHALLENGE_SILENT_FAIL="y"
 
 # Verbose output. It will print all secrets to terminal.
 # Use only for debugging.


### PR DESCRIPTION
As per #68, I added an option to auto-skip unlock.

I called it "silent fail" since I lack a better name for it.
It's not really silent since it still outputs that decryption was tried and skipped.