### PR TITLE
add compatibility with encryptssh

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -150,6 +150,8 @@ ykfde_do_it() {
 
   if [ "$_rc" -eq 0 ]; then
     message "   Decryption was successful."
+    # encryptssh support
+    touch /.done
     if [ "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" ] && [ "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP" -gt 0 ]; then
       [ "$DBG" ] && message " > Making $YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP sleep."
       sleep "$YKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP"


### PR DESCRIPTION
Having to type a long passphrase is not always very easy.
I prefer to log into my linux system from another computer or phone, and use a password manager to copy/paste the decryption phrase. Or sometimes, I want to be able to boot my computer from afar, when I cannot plug my yubikey in it

For that, I use dropbear and encryptssh from mkinitcpio-utils

The issue is that encryptssh is lost when ykfde did successfully opened my disk.
To fix it, I just touch /.done, which encryptssh use to know that the luks volume is opened. 

That way, in the normal setup, when my yubikey is plugged, the boot is automatic, but if it's not, I can start my computer from afar.